### PR TITLE
Absorbs <a> tag into <Link> tag

### DIFF
--- a/imports/ui/Navbar/index.js
+++ b/imports/ui/Navbar/index.js
@@ -17,7 +17,7 @@ export default class Navbar extends Component {
 	                    <span className="icon-bar"></span>
 	                    <span className="icon-bar"></span>
 	                </button>
-	                <h1><Link to="/dashboard"> <a className="navbar-brand">SmirkSpace</a> </Link> </h1>
+	                <h1><Link to="/dashboard" className="navbar-brand">SmirkSpace</Link> </h1>
 
 
 	            </div>
@@ -28,7 +28,7 @@ export default class Navbar extends Component {
 	                </ul>
 	            </div>
 	          </div>
-	          
+
 	        </nav>
 
 	    );


### PR DESCRIPTION
This addresses an error in the Navbar.

Having an <a> tag within a <Link> tag gets interpreted as an <a> tag within an <a> tag, which apparently is not allowed and throws an error in the console...
```
warning.js:36Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>. See Navbar > Link > a > ... > a.
```

To fix this I moved `className=navbar-brand` to the Link tag and removed the a tag altogether.

Closes #67 