### PR TITLE
Removes jquery from shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -93,11 +93,6 @@
       "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
     },
-    "jquery": {
-      "version": "3.1.1",
-      "from": "jquery@latest",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.1.1.tgz"
-    },
     "js-tokens": {
       "version": "2.0.0",
       "from": "js-tokens@>=2.0.0 <3.0.0",


### PR DESCRIPTION
The shrinkwrap file contained instructions to install the latest version of jquery (3.1.1). This caused an error (`Uncaught Error: Bootstrap's JavaScript requires jQuery version 1.9.1 or higher, but lower than version 3`) that prevented the Sign Up / Login dropdown from appearing.  Removing these lines from the shrinkwrap file allows npm to install the version of jquery that is specified in package.json—2.2.0.